### PR TITLE
Split PonyUpgrade into sub-classes per category

### DIFF
--- a/src/core/pony_upgrade.gd
+++ b/src/core/pony_upgrade.gd
@@ -3,17 +3,14 @@ extends Resource
 ## Holds an upgrade ( item ) that can be bought in the shop
 
 enum Category { GLIDER, PROPULSION, BODY }
-enum PropulsionType { NONE, CONTINUOUS, DYNAMIC }
 
  
 @export var display_name: String
-@export var category: Category
 @export var cost: int
 ## Icon for the shop
 @export var icon: Texture2D
 ## An overlay for the flying pony animation adding this upgrades appearance
 @export var overlay_scene: PackedScene
-@export var provides_propulsion: PropulsionType= PropulsionType.NONE
 ## All the stats this upgrade modifies
 @export var pony_stat_modifiers: Array[PonyStatModifier]
 
@@ -26,3 +23,10 @@ func get_stat_modifier(stat: PonyStats.StatType)-> int:
 		if stat == modifier.stat:
 			result+= modifier.value
 	return result
+
+
+## Gets overridden in PonyUpgradeGlider/Propulsion/Body
+## So far it isn't used, may turn out to be unnecessary
+func get_category()-> Category:
+	assert(false, "Abstract function")
+	return Category.GLIDER

--- a/src/core/pony_upgrade_body.gd
+++ b/src/core/pony_upgrade_body.gd
@@ -1,0 +1,6 @@
+class_name PonyUpgradeBody
+extends PonyUpgrade
+
+
+func get_category()-> Category:
+	return Category.BODY

--- a/src/core/pony_upgrade_body.gd.uid
+++ b/src/core/pony_upgrade_body.gd.uid
@@ -1,0 +1,1 @@
+uid://wai2hektb4vk

--- a/src/core/pony_upgrade_glider.gd
+++ b/src/core/pony_upgrade_glider.gd
@@ -1,0 +1,6 @@
+class_name PonyUpgradeGlider
+extends PonyUpgrade
+
+
+func get_category()-> Category:
+	return Category.GLIDER

--- a/src/core/pony_upgrade_glider.gd.uid
+++ b/src/core/pony_upgrade_glider.gd.uid
@@ -1,0 +1,1 @@
+uid://cekl3umqrww32

--- a/src/core/pony_upgrade_propulsion.gd
+++ b/src/core/pony_upgrade_propulsion.gd
@@ -1,0 +1,9 @@
+class_name PonyUpgradePropulsion
+extends PonyUpgrade
+
+enum Type { NONE, CONTINUOUS, DYNAMIC }
+@export var provides_propulsion: Type= Type.NONE
+
+
+func get_category()-> Category:
+	return Category.PROPULSION

--- a/src/core/pony_upgrade_propulsion.gd.uid
+++ b/src/core/pony_upgrade_propulsion.gd.uid
@@ -1,0 +1,1 @@
+uid://bgwt4hvflnx2h

--- a/src/flight/flight_scene.tscn
+++ b/src/flight/flight_scene.tscn
@@ -180,6 +180,13 @@ player = NodePath("Pony")
 [node name="Pony" parent="." instance=ExtResource("2_717lv")]
 position = Vector2(-168, 682.2)
 walk_distance = 489.765
+rotation_speed = null
+jump_angle = null
+gravity = null
+maximum_drag = null
+perfect_lift_angle = null
+fuel_used_per_second = null
+propulsion_force = null
 
 [node name="Floor" type="StaticBody2D" parent="."]
 

--- a/src/flight/flying_pony.gd
+++ b/src/flight/flying_pony.gd
@@ -41,7 +41,7 @@ var enable_lift: bool= false
 ## increased jump height
 var jump_bonus_frames: int= 0
 ## Propulsion type provided by potential upgrade
-var propulsion_type: PonyUpgrade.PropulsionType
+var propulsion_type: PonyUpgradePropulsion.Type
 ## Current state of propulsion
 var propulsion_active: bool
 var remaining_fuel: float
@@ -110,11 +110,11 @@ func fly_logic(delta: float):
 
 	if remaining_fuel > 0:
 		match propulsion_type:
-			PonyUpgrade.PropulsionType.CONTINUOUS:
+			PonyUpgradePropulsion.Type.CONTINUOUS:
 				if not propulsion_active:
 					if Input.is_action_pressed("propulsion"):
 						propulsion_active= true
-			PonyUpgrade.PropulsionType.DYNAMIC:
+			PonyUpgradePropulsion.Type.DYNAMIC:
 				propulsion_active= Input.is_action_pressed("propulsion")
 
 		if propulsion_active:

--- a/src/flight/flying_pony.tscn
+++ b/src/flight/flying_pony.tscn
@@ -9,6 +9,14 @@ radius = 197.8
 
 [node name="Pony" type="CharacterBody2D"]
 script = ExtResource("1_22ryr")
+walk_distance = null
+rotation_speed = null
+jump_angle = null
+gravity = null
+maximum_drag = null
+perfect_lift_angle = null
+fuel_used_per_second = null
+propulsion_force = null
 stats = ExtResource("2_t5pyb")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/src/shop/upgrades/gliders/cardboard_wings_upgrade.tres
+++ b/src/shop/upgrades/gliders/cardboard_wings_upgrade.tres
@@ -1,7 +1,7 @@
-[gd_resource type="Resource" script_class="PonyUpgrade" load_steps=4 format=3 uid="uid://dtf4prfgntfyg"]
+[gd_resource type="Resource" script_class="PonyUpgradeGlider" load_steps=4 format=3 uid="uid://dtf4prfgntfyg"]
 
 [ext_resource type="Script" uid="uid://b7p0gdarn3l0s" path="res://core/pony_stat_modifier.gd" id="1_nro8m"]
-[ext_resource type="Script" uid="uid://fx4ldsmd0ywx" path="res://core/pony_upgrade.gd" id="2_gpg3f"]
+[ext_resource type="Script" uid="uid://cekl3umqrww32" path="res://core/pony_upgrade_glider.gd" id="2_0gkkx"]
 
 [sub_resource type="Resource" id="Resource_nro8m"]
 script = ExtResource("1_nro8m")
@@ -10,9 +10,10 @@ value = 1
 metadata/_custom_type_script = "uid://b7p0gdarn3l0s"
 
 [resource]
-script = ExtResource("2_gpg3f")
+script = ExtResource("2_0gkkx")
 display_name = "Cardboard Wings"
 category = 0
 cost = 15
+provides_propulsion = 0
 pony_stat_modifiers = Array[ExtResource("1_nro8m")]([SubResource("Resource_nro8m")])
 metadata/_custom_type_script = "uid://fx4ldsmd0ywx"

--- a/src/shop/upgrades/gliders/magic_wings_upgrade.tres
+++ b/src/shop/upgrades/gliders/magic_wings_upgrade.tres
@@ -1,11 +1,11 @@
-[gd_resource type="Resource" script_class="PonyUpgrade" load_steps=4 format=3 uid="uid://ceyuh6w1cmev6"]
+[gd_resource type="Resource" script_class="PonyUpgradeGlider" load_steps=4 format=3 uid="uid://ceyuh6w1cmev6"]
 
 [ext_resource type="Script" uid="uid://b7p0gdarn3l0s" path="res://core/pony_stat_modifier.gd" id="1_1dpwv"]
 [ext_resource type="PackedScene" uid="uid://chlhpm5orc2s6" path="res://shop/upgrades/gliders/scenes/magic_wings_upgrade.tscn" id="1_64yea"]
-[ext_resource type="Script" uid="uid://fx4ldsmd0ywx" path="res://core/pony_upgrade.gd" id="2_64yea"]
+[ext_resource type="Script" uid="uid://cekl3umqrww32" path="res://core/pony_upgrade_glider.gd" id="3_64yea"]
 
 [resource]
-script = ExtResource("2_64yea")
+script = ExtResource("3_64yea")
 display_name = "Magic Wings"
 category = 0
 cost = 0

--- a/src/shop/upgrades/propulsion/soda_pop_upgrade.tres
+++ b/src/shop/upgrades/propulsion/soda_pop_upgrade.tres
@@ -1,15 +1,15 @@
-[gd_resource type="Resource" script_class="PonyUpgrade" load_steps=4 format=3 uid="uid://daiqmxni4v3s8"]
+[gd_resource type="Resource" script_class="PonyUpgradePropulsion" load_steps=4 format=3 uid="uid://daiqmxni4v3s8"]
 
 [ext_resource type="PackedScene" uid="uid://s078o8jp4gob" path="res://shop/upgrades/propulsion/scenes/soda_pop/soda_pop_upgrade.tscn" id="1_sc6h6"]
 [ext_resource type="Script" uid="uid://b7p0gdarn3l0s" path="res://core/pony_stat_modifier.gd" id="1_xi8ca"]
-[ext_resource type="Script" uid="uid://fx4ldsmd0ywx" path="res://core/pony_upgrade.gd" id="2_sc6h6"]
+[ext_resource type="Script" uid="uid://bgwt4hvflnx2h" path="res://core/pony_upgrade_propulsion.gd" id="3_sc6h6"]
 
 [resource]
-script = ExtResource("2_sc6h6")
+script = ExtResource("3_sc6h6")
+provides_propulsion = 1
 display_name = "Soda Pop"
 category = 1
 cost = 0
 overlay_scene = ExtResource("1_sc6h6")
-provides_propulsion = 1
 pony_stat_modifiers = Array[ExtResource("1_xi8ca")]([])
 metadata/_custom_type_script = "uid://fx4ldsmd0ywx"

--- a/src/test/flight_test_scene.tscn
+++ b/src/test/flight_test_scene.tscn
@@ -40,6 +40,13 @@ follow_node = NodePath("../Pony")
 [node name="Pony" type="CharacterBody2D" parent="."]
 script = ExtResource("3_3t3je")
 walk_distance = 250.0
+rotation_speed = null
+jump_angle = null
+gravity = null
+maximum_drag = null
+perfect_lift_angle = null
+fuel_used_per_second = null
+propulsion_force = null
 stats = ExtResource("4_is3fb")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Pony"]


### PR DESCRIPTION
We now have specific PonyUpgradeGlider/Propulsion/Body to create our upgrade resource items from and fill with specific functionality and settings